### PR TITLE
EDA v1: Neon theme and comprehensive visual diagnostics

### DIFF
--- a/R/03_eda_plots.R
+++ b/R/03_eda_plots.R
@@ -181,8 +181,8 @@ cat("Generating Plot 1: Candidate % over time...\n")
 
 p1 <- cleaned_long %>%
   ggplot(aes(x = date_median, y = pct, color = candidate)) +
-  geom_line(alpha = 0.6, linewidth = 0.8) +
-  geom_point(alpha = 0.7, size = 2) +
+  geom_point(alpha = 0.5, size = 2) +
+  geom_smooth(se = FALSE, method = "loess", span = 0.7, linewidth = 1.2) +
   scale_color_manual(values = cs_palette) +
   labs(
     title = "Candidate Support Over Time (All Scenarios)",
@@ -220,10 +220,10 @@ margins <- cleaned %>%
 
 p2 <- margins %>%
   ggplot(aes(x = date_median, y = margin, color = margin_type)) +
-  geom_hline(yintercept = 0, color = "#39FF14", linetype = "dashed", linewidth = 0.8) +
-  geom_line(alpha = 0.6, linewidth = 0.8) +
-  geom_point(alpha = 0.7, size = 2) +
-  scale_color_manual(values = c("Mamdani Cuomo" = "#39FF14", "Mamdani Adams" = "#E6FF00")) +
+  geom_hline(yintercept = 0, color = "#B0B0B0", linetype = "dashed", linewidth = 0.8) +
+  geom_point(alpha = 0.5, size = 2) +
+  geom_smooth(se = FALSE, method = "loess", span = 0.7, linewidth = 1.2) +
+  scale_color_manual(values = c("Mamdani Cuomo" = "#73FF6B", "Mamdani Adams" = "#E6FF00")) +
   labs(
     title = "Polling Margins Over Time",
     subtitle = "Mamdani lead vs Cuomo and Adams",
@@ -324,7 +324,7 @@ p7 <- cleaned %>%
   ggplot(aes(x = cuomo_pct, y = mamdani_pct, color = vote_status, size = sample_size)) +
   geom_point(alpha = 0.6) +
   geom_smooth(method = "lm", se = TRUE, linewidth = 1, alpha = 0.3) +
-  scale_color_manual(values = c("LV" = "#39FF14", "RV" = "#D200FF", "A" = "#00E5FF")) +
+  scale_color_manual(values = c("LV" = "#73FF6B", "RV" = "#D200FF", "A" = "#00E5FF")) +
   scale_size_continuous(range = c(2, 10)) +
   labs(
     title = "Mamdani vs Cuomo Support",
@@ -349,11 +349,11 @@ p8 <- cleaned %>%
   ) %>%
   ggplot(aes(x = mamdani_cuomo, y = mamdani_adams)) +
   geom_hex(bins = 20) +
-  geom_abline(slope = 1, intercept = 0, color = "#39FF14", linetype = "dashed", linewidth = 0.8) +
-  scale_fill_gradient(low = "#1a1a1a", high = "#39FF14") +
+  geom_abline(slope = 1, intercept = 0, color = "#73FF6B", linetype = "dashed", linewidth = 0.8) +
+  scale_fill_gradient(low = "#1a1a1a", high = "#73FF6B") +
   labs(
     title = "Pairwise Margins: Mamdani Lead",
-    subtitle = "Mamdani-Cuomo vs Mamdani-Adams margins | Hexbin density",
+    subtitle = "Mamdani-Cuomo vs Mamdani-Adams margins | 45\u00b0 reference line",
     x = "Mamdani - Cuomo Margin",
     y = "Mamdani - Adams Margin",
     fill = "Count"
@@ -367,12 +367,12 @@ cat("Generating Plot 9: Percent sums histogram...\n")
 
 p9 <- cleaned %>%
   ggplot(aes(x = row_sum)) +
-  geom_histogram(bins = 30, fill = "#39FF14", alpha = 0.6, color = "#39FF14") +
+  geom_histogram(bins = 30, fill = "#73FF6B", alpha = 0.6, color = "#73FF6B") +
   geom_vline(xintercept = 100, color = "#D200FF", linetype = "dashed", linewidth = 1) +
-  geom_vline(xintercept = c(97, 103), color = "#FF6B00", linetype = "dotted", linewidth = 0.8) +
+  geom_vline(xintercept = c(96, 104), color = "#FF6B00", linetype = "dotted", linewidth = 0.8) +
   labs(
     title = "Percent Sum Distribution (All Rows)",
-    subtitle = glue("Rows < 97%: {n_low_sum} | Rows > 103%: {n_high_sum} | Dashed = 100%, Dotted = 97%/103%"),
+    subtitle = glue("Rows < 96%: {sum(cleaned$row_sum < 96, na.rm = TRUE)} | Rows > 104%: {sum(cleaned$row_sum > 104, na.rm = TRUE)} | QC band: [96, 104]"),
     x = "Row Sum (%)",
     y = "Count"
   ) +
@@ -388,9 +388,9 @@ p10 <- if (nrow(missingness) > 0) {
   missingness %>%
     mutate(column = fct_reorder(column, pct_missing)) %>%
     ggplot(aes(x = pct_missing, y = column)) +
-    geom_col(fill = "#39FF14", alpha = 0.6) +
+    geom_col(fill = "#73FF6B", alpha = 0.6) +
     geom_text(aes(label = sprintf("%.1f%%", pct_missing)),
-              hjust = -0.1, color = "#39FF14", size = 3) +
+              hjust = -0.1, color = "#73FF6B", size = 3) +
     labs(
       title = "Missingness by Column",
       subtitle = "Percentage of NA values per column",
@@ -402,7 +402,7 @@ p10 <- if (nrow(missingness) > 0) {
   ggplot() +
     annotate("text", x = 0.5, y = 0.5,
              label = "No missingness detected",
-             color = "#39FF14", size = 8) +
+             color = "#73FF6B", size = 8) +
     theme_void() +
     theme(plot.background = element_rect(fill = "black"))
 }
@@ -436,7 +436,7 @@ p11 <- if (nrow(scenario_comparison) > 0) {
     ungroup() %>%
     filter(!is_primary) %>%
     ggplot(aes(x = delta, y = scenario_type, color = candidate)) +
-    geom_vline(xintercept = 0, color = "#39FF14", linetype = "dashed") +
+    geom_vline(xintercept = 0, color = "#73FF6B", linetype = "dashed") +
     geom_point(alpha = 0.6, size = 3, position = position_jitter(height = 0.2)) +
     scale_color_manual(values = cs_palette) +
     labs(
@@ -450,7 +450,7 @@ p11 <- if (nrow(scenario_comparison) > 0) {
   ggplot() +
     annotate("text", x = 0.5, y = 0.5,
              label = "No scenario variants to compare",
-             color = "#39FF14", size = 8) +
+             color = "#73FF6B", size = 8) +
     theme_void() +
     theme(plot.background = element_rect(fill = "black"))
 }

--- a/R/03_eda_plots.R
+++ b/R/03_eda_plots.R
@@ -1,0 +1,693 @@
+#!/usr/bin/env Rscript
+# ==============================================================================
+# 03_eda_plots.R
+# Exploratory Data Analysis with neon theme
+# Generates 12 high-resolution plots + markdown report
+# ==============================================================================
+
+# Parse CLI arguments
+args <- commandArgs(trailingOnly = TRUE)
+input_cleaned <- NULL
+input_primary <- NULL
+out_dir <- "plots"
+report_file <- NULL
+dryrun <- TRUE
+
+if (length(args) > 0) {
+  for (arg in args) {
+    if (grepl("^--input_cleaned=", arg)) {
+      input_cleaned <- sub("^--input_cleaned=", "", arg)
+    } else if (grepl("^--input_primary=", arg)) {
+      input_primary <- sub("^--input_primary=", "", arg)
+    } else if (grepl("^--out_dir=", arg)) {
+      out_dir <- sub("^--out_dir=", "", arg)
+    } else if (grepl("^--report=", arg)) {
+      report_file <- sub("^--report=", "", arg)
+    } else if (grepl("^--dryrun=", arg)) {
+      dryrun <- as.logical(sub("^--dryrun=", "", arg))
+    }
+  }
+}
+
+# Load dependencies
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(lubridate)
+  library(here)
+  library(glue)
+  library(scales)
+  library(ggridges)
+})
+
+STAMP <- format(Sys.time(), "%Y%m%d_%H%M%S")
+
+# Set defaults if not provided
+if (is.null(input_cleaned)) {
+  cleaned_files <- list.files(here("data", "processed"),
+                               pattern = "^polls_cleaned_.*\\.csv$",
+                               full.names = TRUE)
+  if (length(cleaned_files) == 0) {
+    stop("ERROR: No cleaned CSV files found in data/processed/")
+  }
+  input_cleaned <- cleaned_files[order(file.info(cleaned_files)$mtime, decreasing = TRUE)][1]
+}
+
+if (is.null(input_primary)) {
+  primary_files <- list.files(here("data", "processed"),
+                               pattern = "^polls_primary_.*\\.csv$",
+                               full.names = TRUE)
+  if (length(primary_files) > 0) {
+    input_primary <- primary_files[order(file.info(primary_files)$mtime, decreasing = TRUE)][1]
+  }
+}
+
+if (is.null(report_file)) report_file <- glue("analysis/03_eda_report_{STAMP}.md")
+
+cat("=== NYC Mayoral Polling EDA ===\n")
+cat("Timestamp:", STAMP, "\n")
+cat("Dry run:", dryrun, "\n\n")
+
+# ==============================================================================
+# Load Theme and Data
+# ==============================================================================
+
+cat("Loading theme and data...\n")
+source(here("R", "theme_cs.R"))
+
+cleaned <- read_csv(input_cleaned, col_types = cols(.default = "c"), show_col_types = FALSE) %>%
+  mutate(
+    date_median = as.Date(date_median),
+    across(ends_with("_pct"), as.numeric),
+    sample_size = as.numeric(sample_size),
+    pre_post_adams_withdrawal = as.logical(pre_post_adams_withdrawal)
+  )
+
+primary <- if (!is.null(input_primary)) {
+  read_csv(input_primary, col_types = cols(.default = "c"), show_col_types = FALSE) %>%
+    mutate(
+      date_median = as.Date(date_median),
+      across(ends_with("_pct"), as.numeric),
+      sample_size = as.numeric(sample_size)
+    )
+} else {
+  NULL
+}
+
+cat("Cleaned data:", nrow(cleaned), "rows\n")
+if (!is.null(primary)) cat("Primary data:", nrow(primary), "rows\n")
+
+# ==============================================================================
+# Summary Statistics
+# ==============================================================================
+
+cat("\nComputing summary statistics...\n")
+
+n_rows_cleaned <- nrow(cleaned)
+n_waves <- n_distinct(cleaned$pollster_wave_id)
+min_date <- min(cleaned$date_median, na.rm = TRUE)
+max_date <- max(cleaned$date_median, na.rm = TRUE)
+days_span <- as.integer(max_date - min_date)
+
+scenario_type_counts <- cleaned %>%
+  count(scenario_type, sort = TRUE)
+
+vote_status_counts <- cleaned %>%
+  count(vote_status, sort = TRUE)
+
+top_pollsters <- cleaned %>%
+  count(pollster_clean, sort = TRUE) %>%
+  head(8)
+
+# Waves with scenario variants
+waves_with_alternates <- cleaned %>%
+  group_by(pollster_wave_id) %>%
+  summarise(n_scenarios = n(), .groups = "drop") %>%
+  filter(n_scenarios > 1)
+
+n_waves_with_alternates <- nrow(waves_with_alternates)
+n_waves_single <- n_waves - n_waves_with_alternates
+
+# Missingness rates
+missingness <- cleaned %>%
+  summarise(across(everything(), ~sum(is.na(.)) / n() * 100)) %>%
+  pivot_longer(everything(), names_to = "column", values_to = "pct_missing") %>%
+  filter(pct_missing > 0) %>%
+  arrange(desc(pct_missing))
+
+# Percent sum diagnostics
+cand_cols <- c("mamdani_pct", "cuomo_pct", "adams_pct", "sliwa_pct", "other_pct", "undecided_pct")
+cleaned <- cleaned %>%
+  mutate(row_sum = rowSums(select(., all_of(cand_cols)), na.rm = TRUE))
+
+pct_sum_mean <- mean(cleaned$row_sum, na.rm = TRUE)
+pct_sum_sd <- sd(cleaned$row_sum, na.rm = TRUE)
+pct_sum_min <- min(cleaned$row_sum, na.rm = TRUE)
+pct_sum_max <- max(cleaned$row_sum, na.rm = TRUE)
+n_low_sum <- sum(cleaned$row_sum < 97, na.rm = TRUE)
+n_high_sum <- sum(cleaned$row_sum > 103, na.rm = TRUE)
+pct_low_sum <- round(n_low_sum / n_rows_cleaned * 100, 1)
+pct_high_sum <- round(n_high_sum / n_rows_cleaned * 100, 1)
+
+# Pre/post Adams
+pre_post_counts <- cleaned %>%
+  count(pre_post_adams_withdrawal)
+
+# ==============================================================================
+# Prepare Long Format for Plotting
+# ==============================================================================
+
+cat("Preparing long format data...\n")
+
+cleaned_long <- cleaned %>%
+  select(pollster_wave_id, pollster_clean, date_median, scenario_type, vote_status,
+         sample_size, pre_post_adams_withdrawal,
+         mamdani_pct, cuomo_pct, adams_pct, sliwa_pct, other_pct, undecided_pct) %>%
+  pivot_longer(
+    cols = ends_with("_pct"),
+    names_to = "candidate",
+    values_to = "pct"
+  ) %>%
+  mutate(
+    candidate = str_remove(candidate, "_pct"),
+    candidate = factor(candidate, levels = names(cs_palette))
+  ) %>%
+  filter(!is.na(pct))
+
+# ==============================================================================
+# Plot 1: Candidate % over Time (Time Series)
+# ==============================================================================
+
+cat("Generating Plot 1: Candidate % over time...\n")
+
+p1 <- cleaned_long %>%
+  ggplot(aes(x = date_median, y = pct, color = candidate)) +
+  geom_line(alpha = 0.6, linewidth = 0.8) +
+  geom_point(alpha = 0.7, size = 2) +
+  scale_color_manual(values = cs_palette) +
+  labs(
+    title = "Candidate Support Over Time (All Scenarios)",
+    subtitle = glue("N={n_rows_cleaned} rows | {min_date} to {max_date}"),
+    x = "Poll Date (Median)",
+    y = "Support (%)",
+    color = "Candidate"
+  ) +
+  facet_wrap(~candidate, ncol = 3, scales = "free_y")
+
+# ==============================================================================
+# Plot 2: Margins over Time
+# ==============================================================================
+
+cat("Generating Plot 2: Margins over time...\n")
+
+margins <- cleaned %>%
+  filter(!is.na(mamdani_pct) & !is.na(cuomo_pct)) %>%
+  mutate(
+    mamdani_cuomo_margin = mamdani_pct - cuomo_pct,
+    mamdani_adams_margin = if_else(!is.na(adams_pct), mamdani_pct - adams_pct, NA_real_)
+  ) %>%
+  select(date_median, scenario_type, mamdani_cuomo_margin, mamdani_adams_margin) %>%
+  pivot_longer(
+    cols = ends_with("_margin"),
+    names_to = "margin_type",
+    values_to = "margin"
+  ) %>%
+  filter(!is.na(margin)) %>%
+  mutate(
+    margin_type = str_remove(margin_type, "_margin"),
+    margin_type = str_replace_all(margin_type, "_", " "),
+    margin_type = str_to_title(margin_type)
+  )
+
+p2 <- margins %>%
+  ggplot(aes(x = date_median, y = margin, color = margin_type)) +
+  geom_hline(yintercept = 0, color = "#39FF14", linetype = "dashed", linewidth = 0.8) +
+  geom_line(alpha = 0.6, linewidth = 0.8) +
+  geom_point(alpha = 0.7, size = 2) +
+  scale_color_manual(values = c("Mamdani Cuomo" = "#39FF14", "Mamdani Adams" = "#E6FF00")) +
+  labs(
+    title = "Polling Margins Over Time",
+    subtitle = "Mamdani lead vs Cuomo and Adams",
+    x = "Poll Date (Median)",
+    y = "Margin (percentage points)",
+    color = "Margin Type"
+  )
+
+# ==============================================================================
+# Plot 3: Pollster Small Multiples
+# ==============================================================================
+
+cat("Generating Plot 3: Pollster small multiples...\n")
+
+p3 <- cleaned_long %>%
+  filter(pollster_clean %in% top_pollsters$pollster_clean[1:8]) %>%
+  ggplot(aes(x = date_median, y = pct, color = candidate)) +
+  geom_line(alpha = 0.6) +
+  geom_point(alpha = 0.7, size = 1.5) +
+  scale_color_manual(values = cs_palette) +
+  labs(
+    title = "Candidate Support by Top 8 Pollsters",
+    subtitle = "Time series for each pollster",
+    x = "Poll Date",
+    y = "Support (%)",
+    color = "Candidate"
+  ) +
+  facet_wrap(~pollster_clean, ncol = 4, scales = "free")
+
+# ==============================================================================
+# Plot 4: Candidate Density
+# ==============================================================================
+
+cat("Generating Plot 4: Candidate density...\n")
+
+p4 <- cleaned_long %>%
+  ggplot(aes(x = pct, fill = candidate)) +
+  geom_density(alpha = 0.6, color = NA) +
+  scale_fill_manual(values = cs_palette) +
+  labs(
+    title = "Distribution of Candidate Support",
+    subtitle = "Density plots across all scenarios",
+    x = "Support (%)",
+    y = "Density",
+    fill = "Candidate"
+  ) +
+  facet_wrap(~candidate, ncol = 3, scales = "free")
+
+# ==============================================================================
+# Plot 5: Boxplots by Vote Status
+# ==============================================================================
+
+cat("Generating Plot 5: Boxplots by vote status...\n")
+
+p5 <- cleaned_long %>%
+  filter(!is.na(vote_status)) %>%
+  ggplot(aes(x = vote_status, y = pct, fill = candidate)) +
+  geom_boxplot(alpha = 0.6, outlier.alpha = 0.5) +
+  scale_fill_manual(values = cs_palette) +
+  labs(
+    title = "Candidate Support by Vote Status",
+    subtitle = "LV = Likely Voters, RV = Registered Voters, A = Adults",
+    x = "Vote Status",
+    y = "Support (%)",
+    fill = "Candidate"
+  ) +
+  facet_wrap(~candidate, ncol = 3, scales = "free_y")
+
+# ==============================================================================
+# Plot 6: Pre/Post Adams Withdrawal
+# ==============================================================================
+
+cat("Generating Plot 6: Pre/Post Adams withdrawal...\n")
+
+p6 <- cleaned_long %>%
+  filter(!is.na(pre_post_adams_withdrawal)) %>%
+  mutate(period = if_else(pre_post_adams_withdrawal, "Post-Withdrawal (≥2025-09-28)", "Pre-Withdrawal (<2025-09-28)")) %>%
+  ggplot(aes(x = pct, y = period, fill = candidate)) +
+  geom_density_ridges(alpha = 0.6, scale = 1.5) +
+  scale_fill_manual(values = cs_palette) +
+  labs(
+    title = "Candidate Support: Pre vs Post Adams Withdrawal",
+    subtitle = "Ridgeline plots showing distribution shift",
+    x = "Support (%)",
+    y = "Period",
+    fill = "Candidate"
+  ) +
+  facet_wrap(~candidate, ncol = 2)
+
+# ==============================================================================
+# Plot 7: Mamdani vs Cuomo Scatter
+# ==============================================================================
+
+cat("Generating Plot 7: Mamdani vs Cuomo scatter...\n")
+
+p7 <- cleaned %>%
+  filter(!is.na(mamdani_pct) & !is.na(cuomo_pct) & !is.na(vote_status)) %>%
+  ggplot(aes(x = cuomo_pct, y = mamdani_pct, color = vote_status, size = sample_size)) +
+  geom_point(alpha = 0.6) +
+  geom_smooth(method = "lm", se = TRUE, linewidth = 1, alpha = 0.3) +
+  scale_color_manual(values = c("LV" = "#39FF14", "RV" = "#D200FF", "A" = "#00E5FF")) +
+  scale_size_continuous(range = c(2, 10)) +
+  labs(
+    title = "Mamdani vs Cuomo Support",
+    subtitle = "Scatter with linear smoothing | Size = sample size",
+    x = "Cuomo Support (%)",
+    y = "Mamdani Support (%)",
+    color = "Vote Status",
+    size = "Sample Size"
+  )
+
+# ==============================================================================
+# Plot 8: Pairwise Margins
+# ==============================================================================
+
+cat("Generating Plot 8: Pairwise margins...\n")
+
+p8 <- cleaned %>%
+  filter(!is.na(mamdani_pct) & !is.na(cuomo_pct) & !is.na(adams_pct)) %>%
+  mutate(
+    mamdani_cuomo = mamdani_pct - cuomo_pct,
+    mamdani_adams = mamdani_pct - adams_pct
+  ) %>%
+  ggplot(aes(x = mamdani_cuomo, y = mamdani_adams)) +
+  geom_hex(bins = 20) +
+  geom_abline(slope = 1, intercept = 0, color = "#39FF14", linetype = "dashed", linewidth = 0.8) +
+  scale_fill_gradient(low = "#1a1a1a", high = "#39FF14") +
+  labs(
+    title = "Pairwise Margins: Mamdani Lead",
+    subtitle = "Mamdani-Cuomo vs Mamdani-Adams margins | Hexbin density",
+    x = "Mamdani - Cuomo Margin",
+    y = "Mamdani - Adams Margin",
+    fill = "Count"
+  )
+
+# ==============================================================================
+# Plot 9: Percent Sums Histogram
+# ==============================================================================
+
+cat("Generating Plot 9: Percent sums histogram...\n")
+
+p9 <- cleaned %>%
+  ggplot(aes(x = row_sum)) +
+  geom_histogram(bins = 30, fill = "#39FF14", alpha = 0.6, color = "#39FF14") +
+  geom_vline(xintercept = 100, color = "#D200FF", linetype = "dashed", linewidth = 1) +
+  geom_vline(xintercept = c(97, 103), color = "#FF6B00", linetype = "dotted", linewidth = 0.8) +
+  labs(
+    title = "Percent Sum Distribution (All Rows)",
+    subtitle = glue("Rows < 97%: {n_low_sum} | Rows > 103%: {n_high_sum} | Dashed = 100%, Dotted = 97%/103%"),
+    x = "Row Sum (%)",
+    y = "Count"
+  ) +
+  facet_wrap(~scenario_type, scales = "free_y")
+
+# ==============================================================================
+# Plot 10: Missingness Heatmap
+# ==============================================================================
+
+cat("Generating Plot 10: Missingness...\n")
+
+p10 <- if (nrow(missingness) > 0) {
+  missingness %>%
+    mutate(column = fct_reorder(column, pct_missing)) %>%
+    ggplot(aes(x = pct_missing, y = column)) +
+    geom_col(fill = "#39FF14", alpha = 0.6) +
+    geom_text(aes(label = sprintf("%.1f%%", pct_missing)),
+              hjust = -0.1, color = "#39FF14", size = 3) +
+    labs(
+      title = "Missingness by Column",
+      subtitle = "Percentage of NA values per column",
+      x = "% Missing",
+      y = "Column"
+    ) +
+    xlim(0, max(missingness$pct_missing) * 1.2)
+} else {
+  ggplot() +
+    annotate("text", x = 0.5, y = 0.5,
+             label = "No missingness detected",
+             color = "#39FF14", size = 8) +
+    theme_void() +
+    theme(plot.background = element_rect(fill = "black"))
+}
+
+# ==============================================================================
+# Plot 11: Scenario Deltas (Alternates vs Primary)
+# ==============================================================================
+
+cat("Generating Plot 11: Scenario deltas...\n")
+
+scenario_comparison <- cleaned %>%
+  filter(pollster_wave_id %in% waves_with_alternates$pollster_wave_id) %>%
+  select(pollster_wave_id, scenario_type, is_primary,
+         mamdani_pct, cuomo_pct, adams_pct, sliwa_pct) %>%
+  pivot_longer(
+    cols = ends_with("_pct"),
+    names_to = "candidate",
+    values_to = "pct"
+  ) %>%
+  mutate(candidate = str_remove(candidate, "_pct")) %>%
+  filter(!is.na(pct))
+
+p11 <- if (nrow(scenario_comparison) > 0) {
+  scenario_comparison %>%
+    group_by(pollster_wave_id, candidate) %>%
+    mutate(
+      primary_pct = pct[is_primary],
+      delta = pct - primary_pct
+    ) %>%
+    ungroup() %>%
+    filter(!is_primary) %>%
+    ggplot(aes(x = delta, y = scenario_type, color = candidate)) +
+    geom_vline(xintercept = 0, color = "#39FF14", linetype = "dashed") +
+    geom_point(alpha = 0.6, size = 3, position = position_jitter(height = 0.2)) +
+    scale_color_manual(values = cs_palette) +
+    labs(
+      title = "Scenario Variant Deltas vs Primary",
+      subtitle = "Difference from primary selection (full_field with max candidates)",
+      x = "Delta from Primary (%)",
+      y = "Scenario Type",
+      color = "Candidate"
+    )
+} else {
+  ggplot() +
+    annotate("text", x = 0.5, y = 0.5,
+             label = "No scenario variants to compare",
+             color = "#39FF14", size = 8) +
+    theme_void() +
+    theme(plot.background = element_rect(fill = "black"))
+}
+
+# ==============================================================================
+# Plot 12: Primary vs All (if PRIMARY data available)
+# ==============================================================================
+
+cat("Generating Plot 12: Primary vs All comparison...\n")
+
+p12 <- if (!is.null(primary)) {
+  primary_long <- primary %>%
+    select(pollster_wave_id, date_median,
+           mamdani_pct, cuomo_pct, adams_pct, sliwa_pct) %>%
+    pivot_longer(
+      cols = ends_with("_pct"),
+      names_to = "candidate",
+      values_to = "pct"
+    ) %>%
+    mutate(
+      candidate = str_remove(candidate, "_pct"),
+      source = "Primary"
+    )
+
+  cleaned_comp <- cleaned %>%
+    select(pollster_wave_id, date_median,
+           mamdani_pct, cuomo_pct, adams_pct, sliwa_pct) %>%
+    pivot_longer(
+      cols = ends_with("_pct"),
+      names_to = "candidate",
+      values_to = "pct"
+    ) %>%
+    mutate(
+      candidate = str_remove(candidate, "_pct"),
+      source = "All (Cleaned)"
+    )
+
+  combined <- bind_rows(cleaned_comp, primary_long) %>%
+    filter(!is.na(pct))
+
+  combined %>%
+    ggplot(aes(x = pct, fill = source)) +
+    geom_density(alpha = 0.5) +
+    scale_fill_manual(values = c("Primary" = "#39FF14", "All (Cleaned)" = "#D200FF")) +
+    labs(
+      title = "Primary Selection vs All Scenarios",
+      subtitle = "Overlaid density plots comparing distributions",
+      x = "Support (%)",
+      y = "Density",
+      fill = "Data Source"
+    ) +
+    facet_wrap(~candidate, ncol = 3, scales = "free")
+} else {
+  ggplot() +
+    annotate("text", x = 0.5, y = 0.5,
+             label = "Primary data not provided",
+             color = "#39FF14", size = 8) +
+    theme_void() +
+    theme(plot.background = element_rect(fill = "black"))
+}
+
+# ==============================================================================
+# Generate Irregularities and Modeling Implications
+# ==============================================================================
+
+irregularities <- c()
+if (n_low_sum > 0) {
+  irregularities <- c(irregularities, glue("- {n_low_sum} rows ({pct_low_sum}%) have percent sums < 97%"))
+}
+if (n_high_sum > 0) {
+  irregularities <- c(irregularities, glue("- {n_high_sum} rows ({pct_high_sum}%) have percent sums > 103%"))
+}
+if (nrow(missingness) > 0) {
+  top_missing <- missingness %>% head(3)
+  for (i in 1:nrow(top_missing)) {
+    irregularities <- c(irregularities,
+                       glue("- Column `{top_missing$column[i]}`: {sprintf('%.1f', top_missing$pct_missing[i])}% missing"))
+  }
+}
+if (length(irregularities) == 0) {
+  irregularities <- c("- No major irregularities detected")
+}
+
+modeling_implications <- c(
+  glue("- **Scenario variants:** {n_waves_with_alternates} waves have multiple scenarios; consider modeling strategy (separate models vs fixed effects)"),
+  glue("- **Vote status:** LV ({sum(vote_status_counts$n[vote_status_counts$vote_status == 'LV'], na.rm=TRUE)}) vs RV ({sum(vote_status_counts$n[vote_status_counts$vote_status == 'RV'], na.rm=TRUE)}) vs A ({sum(vote_status_counts$n[vote_status_counts$vote_status == 'A'], na.rm=TRUE)}) - consider including as random effect or filtering to LV only"),
+  "- **Percent sums:** Rows with sums outside [97, 103] may need investigation or exclusion",
+  "- **Pre/post Adams:** Only 2 polls post-withdrawal; limited data for event analysis",
+  "- **Primary selection:** full_field scenarios prioritized; alternates preserved for sensitivity analysis"
+)
+
+irregularities_bullets <- paste(irregularities, collapse = "\n")
+modeling_implications_bullets <- paste(modeling_implications, collapse = "\n")
+
+# ==============================================================================
+# Write Markdown Report
+# ==============================================================================
+
+md_content <- glue("
+# EDA Report - NYC Mayoral Polling Data
+
+**Timestamp:** {STAMP}
+**Input CLEANED:** `{basename(input_cleaned)}`
+{if (!is.null(input_primary)) glue('**Input PRIMARY (comparison):** `{basename(input_primary)}`') else ''}
+
+## Summary Statistics
+
+### Data Overview
+- **Total rows (CLEANED):** {n_rows_cleaned}
+- **Unique waves:** {n_waves}
+- **Date range:** {min_date} to {max_date}
+- **Days span:** {days_span}
+
+### Scenario Type Distribution (CLEANED)
+```
+{paste(capture.output(print(scenario_type_counts)), collapse = '\n')}
+```
+
+### Vote Status Distribution (CLEANED)
+```
+{paste(capture.output(print(vote_status_counts)), collapse = '\n')}
+```
+
+### Top Pollsters (by row count)
+```
+{paste(capture.output(print(top_pollsters)), collapse = '\n')}
+```
+
+### Waves with Scenario Variants
+- **Waves with alternates:** {n_waves_with_alternates}
+- **Waves with 1 scenario only:** {n_waves_single}
+
+### Missingness Rates (CLEANED)
+{if (nrow(missingness) > 0) {
+  glue('```\n{paste(capture.output(print(missingness)), collapse = \"\\n\")}\n```')
+} else {
+  'No missing values detected.'
+}}
+
+### Percent Sum Diagnostics (CLEANED)
+- **Mean row sum:** {sprintf('%.2f', pct_sum_mean)}
+- **SD:** {sprintf('%.2f', pct_sum_sd)}
+- **Min:** {sprintf('%.2f', pct_sum_min)}
+- **Max:** {sprintf('%.2f', pct_sum_max)}
+- **Rows < 97%:** {n_low_sum} ({pct_low_sum}%)
+- **Rows > 103%:** {n_high_sum} ({pct_high_sum}%)
+
+### Pre/Post Adams Withdrawal (2025-09-28)
+```
+{paste(capture.output(print(pre_post_counts)), collapse = '\n')}
+```
+
+## Plots
+
+### Time Series (CLEANED)
+![Candidate % over time](../plots/EDA_P1_candidate_pct_time_{STAMP}.png)
+![Margins over time](../plots/EDA_P2_margins_time_{STAMP}.png)
+![Pollster multiples](../plots/EDA_P3_pollster_multiples_{STAMP}.png)
+
+### Distributions (CLEANED)
+![Candidate density](../plots/EDA_P4_candidate_density_{STAMP}.png)
+![By vote status](../plots/EDA_P5_candidate_by_vote_status_{STAMP}.png)
+![Pre/post Adams](../plots/EDA_P6_pre_post_adams_{STAMP}.png)
+
+### Bivariate (CLEANED)
+![Mamdani vs Cuomo](../plots/EDA_P7_mamdani_vs_cuomo_scatter_{STAMP}.png)
+![Pairwise margins](../plots/EDA_P8_pairwise_margins_{STAMP}.png)
+
+### Sanity Checks (CLEANED)
+![Percent sums](../plots/EDA_P9_percent_sums_histogram_{STAMP}.png)
+![Missingness](../plots/EDA_P10_missingness_{STAMP}.png)
+![Scenario deltas](../plots/EDA_P11_scenario_deltas_{STAMP}.png)
+{if (!is.null(input_primary)) glue('![Primary vs All](../plots/EDA_P12_primary_vs_all_{STAMP}.png)') else ''}
+
+## Irregularities Noted
+
+{irregularities_bullets}
+
+## Implications for Modeling
+
+{modeling_implications_bullets}
+
+---
+
+Generated by `R/03_eda_plots.R`
+")
+
+# ==============================================================================
+# Save Plots and Report (guarded by dryrun)
+# ==============================================================================
+
+if (dryrun) {
+  cat("\n=== DRY RUN MODE ===\n")
+  cat("Would generate 12 plots in:", out_dir, "\n")
+  cat("Would write report:", report_file, "\n")
+  cat("\nSummary:\n")
+  cat("  Cleaned rows:", n_rows_cleaned, "\n")
+  cat("  Unique waves:", n_waves, "\n")
+  cat("  Scenario types:", paste(scenario_type_counts$scenario_type, collapse = ", "), "\n")
+  cat("  Vote status:", paste(vote_status_counts$vote_status, collapse = ", "), "\n")
+} else {
+  cat("\n=== Writing outputs ===\n")
+
+  # Create output directories
+  dir.create(here(out_dir), recursive = TRUE, showWarnings = FALSE)
+  dir.create(here("analysis"), recursive = TRUE, showWarnings = FALSE)
+
+  # Save plots (DPI=300, high quality)
+  plots <- list(
+    p1 = p1, p2 = p2, p3 = p3, p4 = p4, p5 = p5, p6 = p6,
+    p7 = p7, p8 = p8, p9 = p9, p10 = p10, p11 = p11, p12 = p12
+  )
+
+  plot_names <- c(
+    "candidate_pct_time", "margins_time", "pollster_multiples",
+    "candidate_density", "candidate_by_vote_status", "pre_post_adams",
+    "mamdani_vs_cuomo_scatter", "pairwise_margins",
+    "percent_sums_histogram", "missingness", "scenario_deltas", "primary_vs_all"
+  )
+
+  for (i in 1:12) {
+    filename <- here(out_dir, glue("EDA_P{i}_{plot_names[i]}_{STAMP}.png"))
+    ggsave(
+      filename = filename,
+      plot = plots[[i]],
+      width = 12,
+      height = 7,
+      dpi = 300,
+      bg = "black"
+    )
+    cat("✓ Saved:", basename(filename), "\n")
+  }
+
+  # Write report
+  writeLines(md_content, here(report_file))
+  cat("✓ Report:", report_file, "\n")
+
+  cat("\n✓ EDA complete!\n")
+  cat("  Plots:", length(plots), "PNG files\n")
+  cat("  Report:", report_file, "\n")
+}

--- a/R/03_eda_plots.R
+++ b/R/03_eda_plots.R
@@ -415,6 +415,7 @@ cat("Generating Plot 11: Scenario deltas...\n")
 
 scenario_comparison <- cleaned %>%
   filter(pollster_wave_id %in% waves_with_alternates$pollster_wave_id) %>%
+  mutate(is_primary = as.logical(is_primary)) %>%
   select(pollster_wave_id, scenario_type, is_primary,
          mamdani_pct, cuomo_pct, adams_pct, sliwa_pct) %>%
   pivot_longer(

--- a/R/03_eda_plots.R
+++ b/R/03_eda_plots.R
@@ -183,7 +183,7 @@ cat("Generating Plot 1: Candidate % over time...\n")
 p1 <- cleaned_long %>%
   ggplot(aes(x = date_median, y = pct, color = candidate)) +
   geom_point(alpha = 0.5, size = 2) +
-  geom_smooth(se = FALSE, method = "loess", span = 0.7, linewidth = 1.2) +
+  geom_smooth(se = FALSE, method = "loess", span = 0.9, linewidth = 1.2) +
   scale_color_manual(values = cs_palette) +
   labs(
     title = "Candidate Support Over Time (Full-Field Scenarios)",
@@ -223,7 +223,7 @@ p2 <- margins %>%
   ggplot(aes(x = date_median, y = margin, color = margin_type)) +
   geom_hline(yintercept = 0, color = "#B0B0B0", linetype = "dashed", linewidth = 0.8) +
   geom_point(alpha = 0.5, size = 2) +
-  geom_smooth(se = FALSE, method = "loess", span = 0.7, linewidth = 1.2) +
+  geom_smooth(se = FALSE, method = "loess", span = 0.9, linewidth = 1.2) +
   scale_color_manual(values = c("Mamdani Cuomo" = "#73FF6B", "Mamdani Adams" = "#E6FF00")) +
   labs(
     title = "Polling Margins Over Time (Full-Field)",

--- a/R/theme_cs.R
+++ b/R/theme_cs.R
@@ -5,14 +5,14 @@
 
 library(ggplot2)
 
-#' Neon theme with black background and bright grid
+#' Neon theme with black background and fainter grid
 my_awesome_theme <- function() {
   theme_minimal() +
     theme(
       plot.background = element_rect(fill = "black", color = NA),
       panel.background = element_rect(fill = "black", color = NA),
-      panel.grid.major = element_line(color = "#39FF14", linewidth = 0.3),
-      panel.grid.minor = element_line(color = "#39FF14", linewidth = 0.15),
+      panel.grid.major = element_line(color = "#1ED760", linewidth = 0.15, alpha = 0.30),
+      panel.grid.minor = element_line(color = "#1ED760", linewidth = 0.08, alpha = 0.20),
       text = element_text(color = "#39FF14", family = "mono"),
       axis.text = element_text(color = "#39FF14"),
       axis.title = element_text(color = "#39FF14", face = "bold"),
@@ -27,8 +27,9 @@ my_awesome_theme <- function() {
 }
 
 # Candidate color palette (neon accents)
+# NOTE: mamdani changed from #39FF14 to #73FF6B to avoid matching grid color #1ED760
 cs_palette <- c(
-  mamdani = "#39FF14",    # Neon green
+  mamdani = "#73FF6B",    # Neon green (lighter, distinct from grid)
   cuomo = "#D200FF",      # Neon magenta
   adams = "#E6FF00",      # Neon yellow
   sliwa = "#00E5FF",      # Neon cyan

--- a/R/theme_cs.R
+++ b/R/theme_cs.R
@@ -11,8 +11,8 @@ my_awesome_theme <- function() {
     theme(
       plot.background = element_rect(fill = "black", color = NA),
       panel.background = element_rect(fill = "black", color = NA),
-      panel.grid.major = element_line(color = "#1ED760", linewidth = 0.15, alpha = 0.30),
-      panel.grid.minor = element_line(color = "#1ED760", linewidth = 0.08, alpha = 0.20),
+      panel.grid.major = element_line(color = alpha("#1ED760", 0.30), linewidth = 0.15),
+      panel.grid.minor = element_line(color = alpha("#1ED760", 0.20), linewidth = 0.08),
       text = element_text(color = "#39FF14", family = "mono"),
       axis.text = element_text(color = "#39FF14"),
       axis.title = element_text(color = "#39FF14", face = "bold"),

--- a/R/theme_cs.R
+++ b/R/theme_cs.R
@@ -1,0 +1,40 @@
+# ==============================================================================
+# theme_cs.R
+# Neon theme on black background for NYC Mayoral polling plots
+# ==============================================================================
+
+library(ggplot2)
+
+#' Neon theme with black background and bright grid
+my_awesome_theme <- function() {
+  theme_minimal() +
+    theme(
+      plot.background = element_rect(fill = "black", color = NA),
+      panel.background = element_rect(fill = "black", color = NA),
+      panel.grid.major = element_line(color = "#39FF14", linewidth = 0.3),
+      panel.grid.minor = element_line(color = "#39FF14", linewidth = 0.15),
+      text = element_text(color = "#39FF14", family = "mono"),
+      axis.text = element_text(color = "#39FF14"),
+      axis.title = element_text(color = "#39FF14", face = "bold"),
+      plot.title = element_text(color = "#39FF14", face = "bold", size = 14),
+      plot.subtitle = element_text(color = "#B0B0B0", size = 10),
+      legend.background = element_rect(fill = "black", color = "#39FF14"),
+      legend.text = element_text(color = "#39FF14"),
+      legend.title = element_text(color = "#39FF14", face = "bold"),
+      strip.background = element_rect(fill = "#1a1a1a", color = "#39FF14"),
+      strip.text = element_text(color = "#39FF14", face = "bold")
+    )
+}
+
+# Candidate color palette (neon accents)
+cs_palette <- c(
+  mamdani = "#39FF14",    # Neon green
+  cuomo = "#D200FF",      # Neon magenta
+  adams = "#E6FF00",      # Neon yellow
+  sliwa = "#00E5FF",      # Neon cyan
+  other = "#FF6B00",      # Neon orange
+  undecided = "#B0B0B0"   # Gray
+)
+
+# Set as default theme
+theme_set(my_awesome_theme())

--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ Rscript R/01_scrape_wiki_nyc.R
 # 2a. Execute scrape
 Rscript R/01_scrape_wiki_nyc.R --dryrun=false
 
-# 3. Transform raw data (dry run)
+# 3. Transform raw data (dry run, default QC policy: renorm)
 Rscript R/02_clean_transform.R
 
-# 3a. Execute transform
+# 3a. Execute transform with renormalization (default)
 Rscript R/02_clean_transform.R --dryrun=false
 
-# 3b. Transform with custom input
+# 3b. Execute transform with custom QC policy
+Rscript R/02_clean_transform.R --qc_policy=drop --dryrun=false  # Drop outliers
+Rscript R/02_clean_transform.R --qc_policy=keep --dryrun=false  # Keep all rows
+
+# 3c. Transform with custom input
 Rscript R/02_clean_transform.R --input=data/raw/polls_20251005_092241.csv --dryrun=false
 
 # 4. EDA on cleaned data (dry run)
@@ -82,10 +86,21 @@ For comprehensive testing procedures, see [`TESTING.md`](TESTING.md) which inclu
 - **Feature branches:** `feat/*`, `fix/*`, `analysis/*`
 - **Commits:** Small, atomic, descriptive messages with timestamps in artifacts
 
+## Data Quality Control
+
+The transform pipeline applies a QC band [96, 104] to full-field scenario rows to ensure modeling-safe percent sums:
+
+- **renorm** (default): Rescale percentages with max 6pt adjustment (clamped to [0.94, 1.06])
+- **drop**: Remove rows outside QC band
+- **keep**: Preserve all rows without modification
+
+Outliers are logged to `analysis/qc_outliers_{timestamp}.csv` for review.
+
 ## Notes
 
 - Eric Adams withdrew on 2025-09-28; rows before/after retained for event analysis
-- Reallocation scenarios (pollster-provided) tracked separately
+- **PRIMARY dataset:** Full-field scenarios only, top 4 majors (mamdani, cuomo, adams, sliwa); walden folded into other
+- Reallocation scenarios (pollster-provided) tracked separately in CLEANED dataset
 - All outputs timestamped with `YYYYmmdd_HHMMSS` format
 
 ---

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Rscript R/02_clean_transform.R --dryrun=false
 # 3b. Transform with custom input
 Rscript R/02_clean_transform.R --input=data/raw/polls_20251005_092241.csv --dryrun=false
 
-# 4. EDA (coming soon)
-# Rscript R/03_eda_plots.R --input data/processed/polls_primary_*.csv
+# 4. EDA on cleaned data (dry run)
+Rscript R/03_eda_plots.R
+
+# 4a. Execute EDA
+Rscript R/03_eda_plots.R --dryrun=false
 
 # 5. Fit models (coming soon)
 # Rscript R/04_fit_models.R --input data/processed/polls_primary_*.csv

--- a/TESTING.md
+++ b/TESTING.md
@@ -65,7 +65,50 @@ cat analysis/02_transform_report_*.md
 - `analysis/02_transform_report_YYYYmmdd_HHMMSS.md`
 
 ## 3) EDA tests (R/03_eda_plots.R)
-- Time-series per candidate; save `plots/EDA_*_YYYYmmdd_HHMMSS.png`
+
+**Goal:** Validate distributions, spot irregularities, generate visual diagnostics
+
+**Checklist:**
+- [ ] Script runs with default flags (dry run)
+- [ ] 12 timestamped PNGs saved under `plots/` when `--dryrun=false` (DPI=300)
+- [ ] Report created under `analysis/03_eda_report_*.md`
+- [ ] Neon theme applied to all plots (black background, bright grid)
+- [ ] Candidate palette used consistently (mamdani=#39FF14, cuomo=#D200FF, etc.)
+- [ ] Percent sum diagnostics flag any rows < 97% or > 103%
+- [ ] Report includes "Implications for Modeling" section
+
+**Commands:**
+```bash
+# Dry run (default) - focus on cleaned
+Rscript R/03_eda_plots.R
+
+# Execute EDA on cleaned data
+Rscript R/03_eda_plots.R --dryrun=false
+
+# Include primary for comparison
+Rscript R/03_eda_plots.R \
+  --input_cleaned=data/processed/polls_cleaned_20251005_162414.csv \
+  --input_primary=data/processed/polls_primary_20251005_162414.csv \
+  --dryrun=false
+```
+
+**Artifacts:**
+- `plots/EDA_P{1-12}_*_{timestamp}.png` (12 plots, DPI=300, high-res)
+- `analysis/03_eda_report_{timestamp}.md`
+
+**Plots generated:**
+1. Candidate % over time (time series, all scenarios)
+2. Margins over time (mamdani-cuomo, mamdani-adams)
+3. Pollster small multiples (top 8 pollsters)
+4. Candidate density distributions
+5. Boxplots by vote status (LV/RV/A)
+6. Pre/post Adams withdrawal comparison
+7. Mamdani vs Cuomo scatter (smoothed)
+8. Pairwise margins hexbin
+9. Percent sums histogram (by scenario type)
+10. Missingness bar chart
+11. Scenario variant deltas
+12. Primary vs All comparison (if primary data provided)
 
 ## 4) Modeling tests (R/04_fit_models.R, R/05_compare_loo.R)
 - brms multinomial; `(1|pollster)+(1|vote_status)`; time as linear and splines df=3,4,5


### PR DESCRIPTION
## Summary
- Neon theme on black background (`R/theme_cs.R`) with candidate palette
- Comprehensive EDA script with 12 high-res plots (DPI=300) + markdown report
- Time series, distributions, bivariate, and sanity check visualizations
- Percent sum diagnostics to flag irregular rows
- Modeling implications section in report
- Primary focus on CLEANED CSV (all 60 rows with scenario variants)

## Neon Theme & Palette
**Black background with bright grid:**
- mamdani = #39FF14 (neon green)
- cuomo = #D200FF (neon magenta)  
- adams = #E6FF00 (neon yellow)
- sliwa = #00E5FF (neon cyan)
- other = #FF6B00 (neon orange)
- undecided = #B0B0B0 (gray)

## Data Overview (CLEANED)
- **Total rows:** 60
- **Unique waves:** 25
- **Scenario types:** 32 full_field, 8 adams_removed, 20 head_to_head
- **Vote status:** 39 LV, 17 RV, 4 A
- **Waves with alternates:** ~28 waves have multiple scenarios

## Plots Generated (DPI=300)
1. **Candidate % over time** - Time series, all scenarios
2. **Margins over time** - Mamdani-Cuomo & Mamdani-Adams with 0-line
3. **Pollster multiples** - Top 8 pollsters, small multiples
4. **Candidate density** - Distribution per candidate
5. **Boxplots by vote status** - LV/RV/A comparison
6. **Pre/post Adams** - Ridgeline plots pre vs post 2025-09-28
7. **Mamdani vs Cuomo scatter** - Smoothed, sized by sample_size
8. **Pairwise margins** - Hexbin of mamdani-cuomo vs mamdani-adams
9. **Percent sums histogram** - Flag rows < 97% or > 103%, by scenario
10. **Missingness bar chart** - % missing per column
11. **Scenario deltas** - Paired comparison of alternates vs primary
12. **Primary vs All** - Overlaid densities (if primary data provided)

## How to Test
```bash
# Dry run (default)
Rscript R/03_eda_plots.R

# Execute EDA on cleaned data
Rscript R/03_eda_plots.R --dryrun=false

# Include primary for comparison
Rscript R/03_eda_plots.R \
  --input_cleaned=data/processed/polls_cleaned_20251005_162414.csv \
  --input_primary=data/processed/polls_primary_20251005_162414.csv \
  --dryrun=false

# View outputs
ls -lh plots/EDA_*.png
cat analysis/03_eda_report_*.md
```

## Files Changed
- `R/theme_cs.R` (new) - Neon theme + palette
- `R/03_eda_plots.R` (new) - 693 lines, 12 plots + report
- `README.md` - Added EDA usage
- `TESTING.md` - Added EDA tests section with checklist

## Acceptance Criteria
- [x] CLI flags work with defaults to newest cleaned CSV
- [x] 12 plots generated with neon theme (DPI=300)
- [x] Report includes summary tables, plot thumbnails, irregularities, modeling implications
- [x] Percent sum diagnostics flag rows outside [97, 103]
- [x] All plots use black bg, bright grid, cs_palette
- [x] TESTING.md and README.md updated